### PR TITLE
Update samples to 3.1

### DIFF
--- a/Quickstart/00-Starter-Seed/WPF/App.config
+++ b/Quickstart/00-Starter-Seed/WPF/App.config
@@ -11,7 +11,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="11.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Quickstart/00-Starter-Seed/WPF/App.config
+++ b/Quickstart/00-Starter-Seed/WPF/App.config
@@ -5,7 +5,7 @@
     <add key="Auth0:ClientId" value="{CLIENT_ID}"/>
   </appSettings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Quickstart/00-Starter-Seed/WPF/MainWindow.xaml.cs
+++ b/Quickstart/00-Starter-Seed/WPF/MainWindow.xaml.cs
@@ -1,21 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using Auth0.OidcClient;
+﻿using Auth0.OidcClient;
 using IdentityModel.OidcClient;
 using IdentityModel.OidcClient.Browser;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Text;
+using System.Windows;
 
 namespace WPFSample
 {
@@ -25,8 +14,7 @@ namespace WPFSample
     public partial class MainWindow : Window
     {
         private Auth0Client client;
-
-        string[] _connectionNames = new string[]
+        readonly string[] _connectionNames = new string[]
         {
             "Username-Password-Authentication",
             "google-oauth2",

--- a/Quickstart/00-Starter-Seed/WPF/Properties/Resources.Designer.cs
+++ b/Quickstart/00-Starter-Seed/WPF/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace WPFSample.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Quickstart/00-Starter-Seed/WPF/Properties/Settings.Designer.cs
+++ b/Quickstart/00-Starter-Seed/WPF/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WPFSample.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Quickstart/00-Starter-Seed/WPF/WPFSample.csproj
+++ b/Quickstart/00-Starter-Seed/WPF/WPFSample.csproj
@@ -105,7 +105,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Auth0.OidcClient.WPF">
-      <Version>2.4.0</Version>
+      <Version>3.1.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Quickstart/00-Starter-Seed/WPF/WPFSample.csproj
+++ b/Quickstart/00-Starter-Seed/WPF/WPFSample.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WPFSample</RootNamespace>
     <AssemblyName>WPFSample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/Quickstart/00-Starter-Seed/WinForms/App.config
+++ b/Quickstart/00-Starter-Seed/WinForms/App.config
@@ -11,7 +11,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="11.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Quickstart/00-Starter-Seed/WinForms/App.config
+++ b/Quickstart/00-Starter-Seed/WinForms/App.config
@@ -5,7 +5,7 @@
     <add key="Auth0:ClientId" value="{CLIENT_ID}"/>
   </appSettings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Quickstart/00-Starter-Seed/WinForms/Properties/Resources.Designer.cs
+++ b/Quickstart/00-Starter-Seed/WinForms/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace WindowsFormsSample.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/Quickstart/00-Starter-Seed/WinForms/Properties/Settings.Designer.cs
+++ b/Quickstart/00-Starter-Seed/WinForms/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace WindowsFormsSample.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.7.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/Quickstart/00-Starter-Seed/WinForms/WindowsFormsSample.csproj
+++ b/Quickstart/00-Starter-Seed/WinForms/WindowsFormsSample.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>WindowsFormsSample</RootNamespace>
     <AssemblyName>WindowsFormsSample</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/Quickstart/00-Starter-Seed/WinForms/WindowsFormsSample.csproj
+++ b/Quickstart/00-Starter-Seed/WinForms/WindowsFormsSample.csproj
@@ -90,7 +90,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Auth0.OidcClient.WinForms">
-      <Version>2.4.0</Version>
+      <Version>3.1.2</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Bumps up the various dependencies to the latest including Auth0.OidcClient.WPF and Auth0.OidcClient.WinForms

Minimum target for .NET Framework is 4.6.2 now.